### PR TITLE
update getHttpStatus

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,26 +83,14 @@ OK
 
 _Sample 2_
 
-**curl "http://localhost:9090/status?code=403"**
+**curl "http://localhost:9090/status?code=400"**
 
 
-will return status code 403 and the following response
+will return status code 400 and the following response
 
 ```console
-FORBIDDEN
+400 BAD_REQUEST
 ```
-
-Currently the following status codes are supported:
-
-| Code  | Status |
-| ------------- | ------------- |
-| 200  | OK  |
-| 403  | FORBIDDEN  |
-| 404  | NOT FOUND  |
-| 500  | INTERNAL SERVER ERROR  |
-| 503  | SERVICE UNAVAILABLE  |
-| 504  | GATEWAY TIMEOUT  |
-
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ _Sample 1_
 will return response with 3000 milliseconds delay
 
 ```console
-Reponse with delay of 3000 milliseconds
+Response with delay of 3000 milliseconds
 ```
 </details>
 

--- a/src/main/java/com/tnite/mock/service/MockService.java
+++ b/src/main/java/com/tnite/mock/service/MockService.java
@@ -12,58 +12,36 @@ import org.springframework.stereotype.Service;
 @Service
 public class MockService {
 	
-	@Autowired
-	ResourceFileLoaderService resourceFileLoader;
-
-    private static Logger logger = LoggerFactory.getLogger(MockService.class);
+    @Autowired
+    private ResourceFileLoaderService resourceFileLoader;
 
     private static final String RESOURCE_FOLDER = "data";
     private static final String EMPTY_DATA_FILENAME = "empty";
+    
+    private static Logger logger = LoggerFactory.getLogger(MockService.class);
 
-    public String getResponse(String foo) {
-        logger.info("Received foo:{}", foo);
-        String contents = resourceFileLoader.getTemplateFromFile(RESOURCE_FOLDER + "/" + foo);
-        logger.info("Received content from file {}: {}", foo, contents);
+    public String getResponse(String data) {
+        logger.info("Received data param:{}", data);
+        String contents = resourceFileLoader.getTemplateFromFile(RESOURCE_FOLDER + "/" + data);
+        logger.info("Received content from file {}: {}", data, contents);
         if (contents.isEmpty()) {
-            logger.info("Could not find contents for {}. Returning empty data", foo);
+            logger.info("Could not find contents for {}. Returning empty data", data);
             return resourceFileLoader.getTemplateFromFile(RESOURCE_FOLDER + "/" + EMPTY_DATA_FILENAME);
         } else {
-        	logger.info("Content is {}, {}", contents, foo);
+        	logger.info("Content is {}, {}", contents, data);
             return contents;
         }
     }
+	
+    public Map<String, HttpStatus> getHttpStatus(int code) {
+        Map<String, HttpStatus> status = new HashMap<String, HttpStatus>();
+        status.put(HttpStatus.valueOf(code).toString(), HttpStatus.valueOf(code));
+        return status;
+    }
 
-	public Map<String, HttpStatus> getHttpStatus(String code) {
-		Map<String, HttpStatus> status = new HashMap<String, HttpStatus>();
-		switch (code) {
-			case "200":
-				status.put("OK", HttpStatus.OK);
-				break;
-			case "403":
-				status.put("FORBIDDEN", HttpStatus.FORBIDDEN);
-				break;
-			case "404":
-				status.put("NOT FOUND", HttpStatus.NOT_FOUND);
-				break;
-			case "500":
-				status.put("INTERNAL SERVER ERROR", HttpStatus.INTERNAL_SERVER_ERROR);
-				break;
-			case "503":
-				status.put("SERVICE UNAVAILABLE", HttpStatus.SERVICE_UNAVAILABLE);
-				break;
-			case "504":
-				status.put("GATEWAY TIMEOUT", HttpStatus.GATEWAY_TIMEOUT);
-				break;
-			default:
-				status.put("OK", HttpStatus.OK);
-				break;
-		}
-		return status;
-	}
-
-	public String getDelay(String time) throws InterruptedException {
-		Long delay = Long.valueOf(time);
-		Thread.sleep(delay);
-		return "Reponse with delay of " + time + " milliseconds";
-	}
+    public String getDelay(String time) throws InterruptedException {
+        Long delay = Long.valueOf(time);
+        Thread.sleep(delay);
+        return "Response with delay of " + time + " milliseconds";
+    }
 }

--- a/src/main/java/com/tnite/mock/service/ResourceFileLoaderService.java
+++ b/src/main/java/com/tnite/mock/service/ResourceFileLoaderService.java
@@ -13,10 +13,10 @@ import io.micrometer.core.instrument.util.IOUtils;
 public class ResourceFileLoaderService {
 
     @Autowired
-    private  ResourceLoader resourceLoader;
+    private ResourceLoader resourceLoader;
 
     public String getTemplateFromFile(String fileName) {
-    	InputStream input = resourceLoader.getClass().getClassLoader().getResourceAsStream(fileName);
+        InputStream input = resourceLoader.getClass().getClassLoader().getResourceAsStream(fileName);
         return IOUtils.toString(input);
     }
 

--- a/src/main/java/com/tnite/mock/service/ResourceFileLoaderService.java
+++ b/src/main/java/com/tnite/mock/service/ResourceFileLoaderService.java
@@ -13,10 +13,10 @@ import io.micrometer.core.instrument.util.IOUtils;
 public class ResourceFileLoaderService {
 
     @Autowired
-    ResourceLoader resourceLoader;
+    private  ResourceLoader resourceLoader;
 
     public String getTemplateFromFile(String fileName) {
-        InputStream input = getClass().getClassLoader().getResourceAsStream(fileName);
+    	InputStream input = resourceLoader.getClass().getClassLoader().getResourceAsStream(fileName);
         return IOUtils.toString(input);
     }
 

--- a/src/main/java/com/tnite/mock/web/MockController.java
+++ b/src/main/java/com/tnite/mock/web/MockController.java
@@ -16,7 +16,7 @@ import com.tnite.mock.service.MockService;
 public class MockController {
 
     @Autowired
-    MockService mockService;
+    private MockService mockService;
 
     @GetMapping(path = "/resource", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<String> getServe(@RequestParam String data) throws Exception {
@@ -25,7 +25,7 @@ public class MockController {
     }
     
     @GetMapping(path = "/status", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<String> getStatus(@RequestParam String code) throws Exception {
+    public ResponseEntity<String> getStatus(@RequestParam int code) throws Exception {
         Map<String, HttpStatus> statusMap = mockService.getHttpStatus(code);
         Map.Entry<String, HttpStatus> status = statusMap.entrySet().iterator().next();
         return new ResponseEntity<>(status.getKey(), status.getValue());

--- a/src/test/java/com/tnite/mock/service/TestMockService.java
+++ b/src/test/java/com/tnite/mock/service/TestMockService.java
@@ -34,58 +34,50 @@ public class TestMockService {
     
     @Test
     public void TestGetHttpStatusWhenRequest200Return200() {
-        Map<String, HttpStatus> statusMap = mockService.getHttpStatus("200");
+        Map<String, HttpStatus> statusMap = mockService.getHttpStatus(200);
         Map.Entry<String, HttpStatus> status = statusMap.entrySet().iterator().next();
-        assertEquals("OK", status.getKey());
+        assertEquals("200 OK", status.getKey());
         assertEquals(HttpStatus.OK, status.getValue());
     }
     
     @Test
     public void TestGetHttpStatusWhenRequest403Return403() {
-        Map<String, HttpStatus> statusMap = mockService.getHttpStatus("403");
+        Map<String, HttpStatus> statusMap = mockService.getHttpStatus(403);
         Map.Entry<String, HttpStatus> status = statusMap.entrySet().iterator().next();
-        assertEquals("FORBIDDEN", status.getKey());
+        assertEquals("403 FORBIDDEN", status.getKey());
         assertEquals(HttpStatus.FORBIDDEN, status.getValue());
     }
     
     @Test
     public void TestGetHttpStatusWhenRequest404Return404() {
-        Map<String, HttpStatus> statusMap = mockService.getHttpStatus("404");
+        Map<String, HttpStatus> statusMap = mockService.getHttpStatus(404);
         Map.Entry<String, HttpStatus> status = statusMap.entrySet().iterator().next();
-        assertEquals("NOT FOUND", status.getKey());
+        assertEquals("404 NOT_FOUND", status.getKey());
         assertEquals(HttpStatus.NOT_FOUND, status.getValue());
     }
     
     @Test
     public void TestGetHttpStatusWhenRequest500Return500() {
-        Map<String, HttpStatus> statusMap = mockService.getHttpStatus("500");
+        Map<String, HttpStatus> statusMap = mockService.getHttpStatus(500);
         Map.Entry<String, HttpStatus> status = statusMap.entrySet().iterator().next();
-        assertEquals("INTERNAL SERVER ERROR", status.getKey());
+        assertEquals("500 INTERNAL_SERVER_ERROR", status.getKey());
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, status.getValue());
     }
     
     @Test
     public void TestGetHttpStatusWhenRequest503Return503() {
-        Map<String, HttpStatus> statusMap = mockService.getHttpStatus("503");
+        Map<String, HttpStatus> statusMap = mockService.getHttpStatus(503);
         Map.Entry<String, HttpStatus> status = statusMap.entrySet().iterator().next();
-        assertEquals("SERVICE UNAVAILABLE", status.getKey());
+        assertEquals("503 SERVICE_UNAVAILABLE", status.getKey());
         assertEquals(HttpStatus.SERVICE_UNAVAILABLE, status.getValue());
     }
     
     @Test
     public void TestGetHttpStatusWhenRequest504Return504() {
-        Map<String, HttpStatus> statusMap = mockService.getHttpStatus("504");
+        Map<String, HttpStatus> statusMap = mockService.getHttpStatus(504);
         Map.Entry<String, HttpStatus> status = statusMap.entrySet().iterator().next();
-        assertEquals("GATEWAY TIMEOUT", status.getKey());
+        assertEquals("504 GATEWAY_TIMEOUT", status.getKey());
         assertEquals(HttpStatus.GATEWAY_TIMEOUT, status.getValue());
-    }
-    
-    @Test
-    public void TestGetHttpStatusWhenRequestUnsupportedCodeReturnDefault200() {
-        Map<String, HttpStatus> statusMap = mockService.getHttpStatus("999");
-        Map.Entry<String, HttpStatus> status = statusMap.entrySet().iterator().next();
-        assertEquals("OK", status.getKey());
-        assertEquals(HttpStatus.OK, status.getValue());
     }
 
     @Test

--- a/src/test/java/com/tnite/mock/web/TestMockController.java
+++ b/src/test/java/com/tnite/mock/web/TestMockController.java
@@ -46,7 +46,7 @@ public class TestMockController {
     
     @Test
     public void testThatWhenStatusRequestWithCode200ThenResponseReturnTheSame() throws Exception {
-    	when(mockService.getHttpStatus("200")).thenReturn(Collections.singletonMap("OK", HttpStatus.OK));
+    	when(mockService.getHttpStatus(200)).thenReturn(Collections.singletonMap("OK", HttpStatus.OK));
     	
         RequestBuilder requestBuilder = MockMvcRequestBuilders.get("/status?code=200").accept(MediaType.APPLICATION_JSON);
 		MvcResult result = mockMvc.perform(requestBuilder).andReturn();


### PR DESCRIPTION
MockService.java
- fix formatting 
- make ResourceFileLoaderService private
- rename variable foo to data
- rewrite getHttpStatus

ResourceFileLoaderService.java
- use resourceLoader instead of calling getClass directly

MockController.java
- make mockService private
- change code parameter to int for status endpoint
- fix typo for delay response

README
- remove obsolete info for status endpoint
- fix typo for delay response